### PR TITLE
Added MAC filter support for WiFi profiles

### DIFF
--- a/apcontroller/files/usr/bin/apcontroller-sendconfig
+++ b/apcontroller/files/usr/bin/apcontroller-sendconfig
@@ -1,48 +1,41 @@
 #!/bin/sh
 #
-# (c) 2025 Cezary Jackiewicz
-# MAC filter extension
+# (c) 2025 Cezary Jackiewicz <cezary@eko.one.pl>
+#
 
-SEC="$1"
+SEC=$1
 [ -z "$SEC" ] && exit 0
 
-VERBOSE="$2"
+VERBOSE=$2
 
 . /usr/share/libubox/jshn.sh
 
 BASEPATH="/tmp/apcontroller"
-T="$(uci -q get apcontroller.@global[0].path)"
+T=$(uci -q get apcontroller.@global[0].path)
 [ -n "$T" ] && BASEPATH="$T"
-
 mkdir -p "$BASEPATH"
 
-T="$(uci -q get apcontroller."$SEC")"
+T=$(uci -q get apcontroller."$SEC")
 [ "x$T" = "xgroup" ] || exit 0
 
-HOSTS="$(uci -q get apcontroller."$SEC".host)"
+HOSTS=$(uci -q get apcontroller."$SEC".host)
 [ -z "$HOSTS" ] && exit 0
-
-WIFIS="$(uci -q get apcontroller."$SEC".wifi)"
+WIFIS=$(uci -q get apcontroller."$SEC".wifi)
 [ -z "$WIFIS" ] && exit 0
 
 json_init
 
-DELETE="$(uci -q get apcontroller."$SEC".delete)"
+DELETE=$(uci -q get apcontroller."$SEC".delete)
 [ "x$DELETE" = "x1" ] && json_add_int "delete" 1
 
 json_add_array "wifis"
-
 for WIFI in $WIFIS; do
 	BANDS="$(uci -q get apcontroller."$WIFI".band)"
-
 	MACFILTER="$(uci -q get apcontroller."$WIFI".macfilter)"
 	[ -z "$MACFILTER" ] && MACFILTER="disable"
-
 	MACLIST="$(uci -q get apcontroller."$WIFI".maclist)"
-
 	for BAND in $BANDS; do
 		json_add_object
-
 		json_add_int "enabled" "$(uci -q get apcontroller."$WIFI".enabled)"
 		json_add_string "band" "$BAND"
 		json_add_string "ssid" "$(uci -q get apcontroller."$WIFI".ssid)"
@@ -51,7 +44,6 @@ for WIFI in $WIFIS; do
 		json_add_int "hidden" "$(uci -q get apcontroller."$WIFI".hidden)"
 		json_add_int "isolate" "$(uci -q get apcontroller."$WIFI".isolate)"
 		json_add_string "network" "$(uci -q get apcontroller."$WIFI".network)"
-
 		json_add_string "macfilter" "$MACFILTER"
 		json_add_array "maclist"
 		for MAC in $MACLIST; do
@@ -59,98 +51,60 @@ for WIFI in $WIFIS; do
 			json_add_string "" "$MAC"
 		done
 		json_close_array
-
 		json_close_object
 	done
 done
-
 json_close_array
 
-json_dump > "${BASEPATH}/cmds-${SEC}"
+json_dump > ${BASEPATH}/cmds-${SEC}
 
-USEAS="$(uci -q get apcontroller."$SEC".useadditionalscript)"
+USEAS=$(uci -q get apcontroller."$SEC".useadditionalscript)
 
 for HOST in $HOSTS; do
-	enabled="$(uci -q get apcontroller."$HOST".enabled)"
-	[ "$enabled" = "1" ] || continue
+	enabled=$(uci -q get apcontroller."$HOST".enabled)
+	[ "$enabled" -eq 1 ] || continue
 
-	ipaddr="$(uci -q get apcontroller."$HOST".ipaddr)"
+	ipaddr=$(uci -q get apcontroller."$HOST".ipaddr)
 	[ -z "$ipaddr" ] && continue
-
-	port="$(uci -q get apcontroller."$HOST".port)"
+	port=$(uci -q get apcontroller."$HOST".port)
 	[ -z "$port" ] && port=22
-
-	username="$(uci -q get apcontroller."$HOST".username)"
+	username=$(uci -q get apcontroller."$HOST".username)
 	[ -z "$username" ] && continue
+	password=$(uci -q get apcontroller."$HOST".password)
 
-	password="$(uci -q get apcontroller."$HOST".password)"
-	usekeyfile="$(uci -q get apcontroller."$HOST".usekeyfile)"
-	keyfile="$(uci -q get apcontroller."$HOST".keyfile)"
-
-	T=1
+	usekeyfile=$(uci -q get apcontroller."$HOST".usekeyfile)
+	keyfile=$(uci -q get apcontroller."$HOST".keyfile)
 
 	if [ "x$usekeyfile" = "x1" ] && [ -e "$keyfile" ]; then
 		if [ "x$USEAS" = "x1" ]; then
-			scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
-				/usr/share/apcontroller/apcontroller.user \
-				"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-			scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
-				/usr/share/apcontroller/apcontroller-agent-as \
-				"${username}@${ipaddr}:/tmp" 2>/dev/null
+			scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller.user ${username}@${ipaddr}:/tmp 2>/dev/null
+			scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-as ${username}@${ipaddr}:/tmp 2>/dev/null
 		fi
-
-		scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
-			"${BASEPATH}/cmds-${SEC}" \
-			"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-		[ $? -eq 0 ] && scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
-			/usr/share/apcontroller/apcontroller-agent-setconfig \
-			"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-		[ $? -eq 0 ] && ssh -q -i "$keyfile" -o StrictHostKeyChecking=no -p "$port" \
-			"${username}@${ipaddr}" \
-			"/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
-
+		scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} ${BASEPATH}/cmds-${SEC} ${username}@${ipaddr}:/tmp 2>/dev/null
+		[ $? -eq 0 ] && scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-setconfig ${username}@${ipaddr}:/tmp 2>/dev/null
+		[ $? -eq 0 ] && ssh -q -i ${keyfile} -o StrictHostKeyChecking=no -p ${port} ${username}@${ipaddr} "/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
 		T=$?
 	else
 		if [ "x$USEAS" = "x1" ]; then
-			sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
-				/usr/share/apcontroller/apcontroller.user \
-				"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-			sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
-				/usr/share/apcontroller/apcontroller-agent-as \
-				"${username}@${ipaddr}:/tmp" 2>/dev/null
+			sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller.user ${username}@${ipaddr}:/tmp 2>/dev/null
+			sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-as ${username}@${ipaddr}:/tmp 2>/dev/null
 		fi
-
-		sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
-			"${BASEPATH}/cmds-${SEC}" \
-			"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-		[ $? -eq 0 ] && sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
-			/usr/share/apcontroller/apcontroller-agent-setconfig \
-			"${username}@${ipaddr}:/tmp" 2>/dev/null
-
-		[ $? -eq 0 ] && sshpass -p "$password" ssh -q -o StrictHostKeyChecking=no -p "$port" \
-			"${username}@${ipaddr}" \
-			"/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
-
+		sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} ${BASEPATH}/cmds-${SEC} ${username}@${ipaddr}:/tmp 2>/dev/null
+		[ $? -eq 0 ] && sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-setconfig ${username}@${ipaddr}:/tmp 2>/dev/null
+		[ $? -eq 0 ] && sshpass -p "${password}" ssh -q -o StrictHostKeyChecking=no -p ${port} ${username}@${ipaddr} "/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
 		T=$?
 	fi
-
 	if [ -n "$VERBOSE" ]; then
 		if [ "$T" -eq 0 ]; then
 			RET="OK"
 		else
 			RET="ERROR"
 		fi
-
-		NAME="$(uci -q get apcontroller."$HOST".name)"
+		NAME=$(uci -q get apcontroller."$HOST".name)
 		echo "${NAME} (${ipaddr}): ${RET}"
 	fi
 done
 
-rm -f "${BASEPATH}/cmds-${SEC}"
+rm ${BASEPATH}/cmds-${SEC} 2>/dev/null
 
 exit 0

--- a/apcontroller/files/usr/bin/apcontroller-sendconfig
+++ b/apcontroller/files/usr/bin/apcontroller-sendconfig
@@ -1,39 +1,48 @@
 #!/bin/sh
-
 #
-# (c) 2025 Cezary Jackiewicz <cezary@eko.one.pl>
-#
+# (c) 2025 Cezary Jackiewicz
+# MAC filter extension
 
-SEC=$1
+SEC="$1"
 [ -z "$SEC" ] && exit 0
 
-VERBOSE=$2
+VERBOSE="$2"
 
 . /usr/share/libubox/jshn.sh
 
 BASEPATH="/tmp/apcontroller"
-T=$(uci -q get apcontroller.@global[0].path)
+T="$(uci -q get apcontroller.@global[0].path)"
 [ -n "$T" ] && BASEPATH="$T"
+
 mkdir -p "$BASEPATH"
 
-T=$(uci -q get apcontroller."$SEC")
+T="$(uci -q get apcontroller."$SEC")"
 [ "x$T" = "xgroup" ] || exit 0
 
-HOSTS=$(uci -q get apcontroller."$SEC".host)
+HOSTS="$(uci -q get apcontroller."$SEC".host)"
 [ -z "$HOSTS" ] && exit 0
-WIFIS=$(uci -q get apcontroller."$SEC".wifi)
+
+WIFIS="$(uci -q get apcontroller."$SEC".wifi)"
 [ -z "$WIFIS" ] && exit 0
 
 json_init
 
-DELETE=$(uci -q get apcontroller."$SEC".delete)
+DELETE="$(uci -q get apcontroller."$SEC".delete)"
 [ "x$DELETE" = "x1" ] && json_add_int "delete" 1
 
 json_add_array "wifis"
+
 for WIFI in $WIFIS; do
 	BANDS="$(uci -q get apcontroller."$WIFI".band)"
+
+	MACFILTER="$(uci -q get apcontroller."$WIFI".macfilter)"
+	[ -z "$MACFILTER" ] && MACFILTER="disable"
+
+	MACLIST="$(uci -q get apcontroller."$WIFI".maclist)"
+
 	for BAND in $BANDS; do
 		json_add_object
+
 		json_add_int "enabled" "$(uci -q get apcontroller."$WIFI".enabled)"
 		json_add_string "band" "$BAND"
 		json_add_string "ssid" "$(uci -q get apcontroller."$WIFI".ssid)"
@@ -42,60 +51,106 @@ for WIFI in $WIFIS; do
 		json_add_int "hidden" "$(uci -q get apcontroller."$WIFI".hidden)"
 		json_add_int "isolate" "$(uci -q get apcontroller."$WIFI".isolate)"
 		json_add_string "network" "$(uci -q get apcontroller."$WIFI".network)"
+
+		json_add_string "macfilter" "$MACFILTER"
+		json_add_array "maclist"
+		for MAC in $MACLIST; do
+			MAC="$(echo "$MAC" | tr '[:lower:]' '[:upper:]')"
+			json_add_string "" "$MAC"
+		done
+		json_close_array
+
 		json_close_object
 	done
 done
+
 json_close_array
 
-json_dump > ${BASEPATH}/cmds-${SEC}
+json_dump > "${BASEPATH}/cmds-${SEC}"
 
-USEAS=$(uci -q get apcontroller."$SEC".useadditionalscript)
+USEAS="$(uci -q get apcontroller."$SEC".useadditionalscript)"
 
 for HOST in $HOSTS; do
-	enabled=$(uci -q get apcontroller."$HOST".enabled)
-	[ "$enabled" -eq 1 ] || continue
+	enabled="$(uci -q get apcontroller."$HOST".enabled)"
+	[ "$enabled" = "1" ] || continue
 
-	ipaddr=$(uci -q get apcontroller."$HOST".ipaddr)
+	ipaddr="$(uci -q get apcontroller."$HOST".ipaddr)"
 	[ -z "$ipaddr" ] && continue
-	port=$(uci -q get apcontroller."$HOST".port)
-	[ -z "$port" ] && port=22
-	username=$(uci -q get apcontroller."$HOST".username)
-	[ -z "$username" ] && continue
-	password=$(uci -q get apcontroller."$HOST".password)
 
-	usekeyfile=$(uci -q get apcontroller."$HOST".usekeyfile)
-	keyfile=$(uci -q get apcontroller."$HOST".keyfile)
+	port="$(uci -q get apcontroller."$HOST".port)"
+	[ -z "$port" ] && port=22
+
+	username="$(uci -q get apcontroller."$HOST".username)"
+	[ -z "$username" ] && continue
+
+	password="$(uci -q get apcontroller."$HOST".password)"
+	usekeyfile="$(uci -q get apcontroller."$HOST".usekeyfile)"
+	keyfile="$(uci -q get apcontroller."$HOST".keyfile)"
+
+	T=1
 
 	if [ "x$usekeyfile" = "x1" ] && [ -e "$keyfile" ]; then
 		if [ "x$USEAS" = "x1" ]; then
-			scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller.user ${username}@${ipaddr}:/tmp 2>/dev/null
-			scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-as ${username}@${ipaddr}:/tmp 2>/dev/null
+			scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
+				/usr/share/apcontroller/apcontroller.user \
+				"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+			scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
+				/usr/share/apcontroller/apcontroller-agent-as \
+				"${username}@${ipaddr}:/tmp" 2>/dev/null
 		fi
-		scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} ${BASEPATH}/cmds-${SEC} ${username}@${ipaddr}:/tmp 2>/dev/null
-		[ $? -eq 0 ] && scp -i ${keyfile} -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-setconfig ${username}@${ipaddr}:/tmp 2>/dev/null
-		[ $? -eq 0 ] && ssh -q -i ${keyfile} -o StrictHostKeyChecking=no -p ${port} ${username}@${ipaddr} "/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
+
+		scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
+			"${BASEPATH}/cmds-${SEC}" \
+			"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+		[ $? -eq 0 ] && scp -i "$keyfile" -o StrictHostKeyChecking=no -P "$port" \
+			/usr/share/apcontroller/apcontroller-agent-setconfig \
+			"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+		[ $? -eq 0 ] && ssh -q -i "$keyfile" -o StrictHostKeyChecking=no -p "$port" \
+			"${username}@${ipaddr}" \
+			"/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
+
 		T=$?
 	else
 		if [ "x$USEAS" = "x1" ]; then
-			sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller.user ${username}@${ipaddr}:/tmp 2>/dev/null
-			sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-as ${username}@${ipaddr}:/tmp 2>/dev/null
+			sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
+				/usr/share/apcontroller/apcontroller.user \
+				"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+			sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
+				/usr/share/apcontroller/apcontroller-agent-as \
+				"${username}@${ipaddr}:/tmp" 2>/dev/null
 		fi
-		sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} ${BASEPATH}/cmds-${SEC} ${username}@${ipaddr}:/tmp 2>/dev/null
-		[ $? -eq 0 ] && sshpass -p "${password}" scp -o StrictHostKeyChecking=no -P ${port} /usr/share/apcontroller/apcontroller-agent-setconfig ${username}@${ipaddr}:/tmp 2>/dev/null
-		[ $? -eq 0 ] && sshpass -p "${password}" ssh -q -o StrictHostKeyChecking=no -p ${port} ${username}@${ipaddr} "/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
+
+		sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
+			"${BASEPATH}/cmds-${SEC}" \
+			"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+		[ $? -eq 0 ] && sshpass -p "$password" scp -o StrictHostKeyChecking=no -P "$port" \
+			/usr/share/apcontroller/apcontroller-agent-setconfig \
+			"${username}@${ipaddr}:/tmp" 2>/dev/null
+
+		[ $? -eq 0 ] && sshpass -p "$password" ssh -q -o StrictHostKeyChecking=no -p "$port" \
+			"${username}@${ipaddr}" \
+			"/tmp/apcontroller-agent-setconfig /tmp/cmds-${SEC}" >/dev/null 2>&1
+
 		T=$?
 	fi
+
 	if [ -n "$VERBOSE" ]; then
 		if [ "$T" -eq 0 ]; then
 			RET="OK"
 		else
 			RET="ERROR"
 		fi
-		NAME=$(uci -q get apcontroller."$HOST".name)
+
+		NAME="$(uci -q get apcontroller."$HOST".name)"
 		echo "${NAME} (${ipaddr}): ${RET}"
 	fi
 done
 
-rm ${BASEPATH}/cmds-${SEC} 2>/dev/null
+rm -f "${BASEPATH}/cmds-${SEC}"
 
 exit 0

--- a/apcontroller/files/usr/share/apcontroller/apcontroller-agent-setconfig
+++ b/apcontroller/files/usr/share/apcontroller/apcontroller-agent-setconfig
@@ -1,64 +1,100 @@
 #!/bin/sh
 
-FILE=$1
-[ -s "$FILE" ] || exit 1
+FILE="$1"
 
+[ -s "$FILE" ] || exit 1
 [ -e /etc/config/wireless ] || exit 1
 
-function wifi_add() {
-	local RADIO=$1
-	local NETWORK=$2
-	local ENABLED=$3
-	local SSID=$4
-	local ENCRYPTION=$5
-	local KEY=$6
-	local HIDDEN=$7
-	local ISOLATE=$8
+wifi_set_macfilter() {
+	local SEC="$1"
+	local MACFILTER="$2"
+	local MACLIST="$3"
+	local MAC
 
-	CNT=$(uci show wireless | awk '/\.device=/ {count++} END {print count + 1}')
+	uci -q del wireless."$SEC".macfilter
+	uci -q del wireless."$SEC".maclist
+
+	case "$MACFILTER" in
+		allow|deny)
+			uci set wireless."$SEC".macfilter="$MACFILTER"
+
+			for MAC in $MACLIST; do
+				[ -n "$MAC" ] || continue
+				MAC="$(echo "$MAC" | tr '[:lower:]' '[:upper:]')"
+				uci add_list wireless."$SEC".maclist="$MAC"
+			done
+		;;
+	esac
+}
+
+wifi_add() {
+	local RADIO="$1"
+	local NETWORK="$2"
+	local ENABLED="$3"
+	local SSID="$4"
+	local ENCRYPTION="$5"
+	local KEY="$6"
+	local HIDDEN="$7"
+	local ISOLATE="$8"
+	local MACFILTER="$9"
+	local MACLIST="${10}"
+
+	CNT="$(uci show wireless | awk '/\.device=/ {count++} END {print count + 1}')"
+
 	while [ -n "$(uci -q get wireless.wifinet"$CNT")" ]; do
 		CNT=$((CNT + 1))
 	done
+
 	SEC="wifinet${CNT}"
 
 	uci set wireless."$SEC"=wifi-iface
-	uci set wireless."$SEC".device=$RADIO
+	uci set wireless."$SEC".device="$RADIO"
 	uci set wireless."$SEC".mode=ap
 	uci set wireless."$SEC".network="$NETWORK"
+
 	if [ "$ENABLED" -eq 0 ]; then
 		uci set wireless."$SEC".disabled=1
 	else
 		uci -q del wireless."$RADIO".disabled
 	fi
+
 	uci set wireless."$SEC".ssid="$SSID"
 	uci set wireless."$SEC".encryption="$ENCRYPTION"
 	uci set wireless."$SEC".key="$KEY"
 	uci set wireless."$SEC".hidden="${HIDDEN:-0}"
 	uci set wireless."$SEC".isolate="${ISOLATE:-0}"
+
+	wifi_set_macfilter "$SEC" "$MACFILTER" "$MACLIST"
 }
 
-function wifi_update() {
-	local SEC=$1
-	local RADIO=$2
-	local ENABLED=$3
-	local SSID=$4
-	local ENCRYPTION=$5
-	local KEY=$6
-	local HIDDEN=$7
-	local ISOLATE=$8
+wifi_update() {
+	local SEC="$1"
+	local RADIO="$2"
+	local ENABLED="$3"
+	local SSID="$4"
+	local ENCRYPTION="$5"
+	local KEY="$6"
+	local HIDDEN="$7"
+	local ISOLATE="$8"
+	local MACFILTER="$9"
+	local MACLIST="${10}"
 
 	uci -q del wireless."$RADIO".disabled
+
 	if [ "$ENABLED" -eq 0 ]; then
 		uci set wireless."$SEC".disabled=1
 	else
 		uci -q del wireless."$RADIO".disabled
 		uci -q del wireless."$SEC".disabled
 	fi
+
 	uci set wireless."$SEC".ssid="$SSID"
 	uci set wireless."$SEC".encryption="$ENCRYPTION"
 	uci set wireless."$SEC".key="$KEY"
 	uci set wireless."$SEC".hidden="${HIDDEN:-0}"
 	uci set wireless."$SEC".isolate="${ISOLATE:-0}"
+
+	wifi_set_macfilter "$SEC" "$MACFILTER" "$MACLIST"
 }
 
 . /usr/share/libubox/jshn.sh
@@ -66,27 +102,48 @@ function wifi_update() {
 NEEDCOMMIT=0
 
 json_load_file "$FILE"
-
 json_is_a wifis array || exit 2
 
 json_get_var delete delete
+
 if [ "x$delete" = "x1" ]; then
-	EXISTING=$(uci show wireless | awk -F[.=] '/=wifi-iface$/{print $2}')
+	EXISTING="$(uci show wireless | awk -F[.=] '/=wifi-iface$/{print $2}')"
+
 	for SECTION in $EXISTING; do
 		uci -q del wireless."$SECTION"
 	done
+
 	NEEDCOMMIT=1
 fi
 
 json_select "wifis"
+
 IDX=1
-while json_is_a $IDX object; do
-	json_select $IDX
-	json_get_vars enabled band network ssid encryption key hidden isolate
+
+while json_is_a "$IDX" object; do
+	json_select "$IDX"
+
+	json_get_vars enabled band network ssid encryption key hidden isolate macfilter
+
+	[ -z "$macfilter" ] && macfilter="disable"
+
+	MACLIST=""
+	if json_is_a maclist array; then
+		json_select maclist
+
+		MACIDX=1
+		while json_is_a "$MACIDX" string; do
+			json_get_var MAC "$MACIDX"
+			[ -n "$MAC" ] && MACLIST="${MACLIST} ${MAC}"
+			MACIDX=$((MACIDX + 1))
+		done
+
+		json_select ..
+	fi
 
 	[ -e /tmp/apcontroller.user ] && sh /tmp/apcontroller-agent-as "$enabled" "$ssid" "$band" "$network"
 
-	T=$(uci -q get network."$network")
+	T="$(uci -q get network."$network")"
 	if [ -z "$T" ]; then
 		IDX=$((IDX + 1))
 		json_select ..
@@ -94,45 +151,53 @@ while json_is_a $IDX object; do
 	fi
 
 	RADIOS=""
+
 	case "$band" in
 		"2g")
-			RADIOS=$(uci show wireless | awk -F. '/\.hwmode='\''11g'\''$|\.band='\''2g'\''/{print $2}')
-			;;
+			RADIOS="$(uci show wireless | awk -F. '/\.hwmode='\''11g'\''$|\.band='\''2g'\''/{print $2}')"
+		;;
 		"5g")
-			RADIOS=$(uci show wireless | awk -F. '/\.hwmode='\''11a'\''$|\.band='\''5g'\''/{print $2}')
-			;;
+			RADIOS="$(uci show wireless | awk -F. '/\.hwmode='\''11a'\''$|\.band='\''5g'\''/{print $2}')"
+		;;
 		"6g")
-			RADIOS=$(uci show wireless | awk -F. '/\.band='\''6g'\''/{print $2}')
-			;;
+			RADIOS="$(uci show wireless | awk -F. '/\.band='\''6g'\''/{print $2}')"
+		;;
 	esac
+
 	if [ -z "$RADIOS" ]; then
 		IDX=$((IDX + 1))
 		json_select ..
 		continue
 	fi
 
-	SECTIONS=$(uci -q show wireless | awk -F. '/\.ssid='\'''"$ssid"''\''$/{print $2}')
+	SECTIONS="$(uci -q show wireless | awk -F. '/\.ssid='\'''"$ssid"''\''$/{print $2}')"
+
 	if [ -z "$SECTIONS" ]; then
 		for RADIO in $RADIOS; do
-			wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate"
+			wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 		done
+
 		NEEDCOMMIT=1
 	else
 		for RADIO in $RADIOS; do
 			FOUND=0
+
 			for SECTION in $SECTIONS; do
-				T1=$(uci get wireless."$SECTION".device)
+				T1="$(uci get wireless."$SECTION".device)"
+
 				if [ "$T1" = "$RADIO" ]; then
-					T2=$(uci get wireless."$SECTION".network)
+					T2="$(uci get wireless."$SECTION".network)"
+
 					if [ "$T2" = "$network" ]; then
-						wifi_update "$SECTION" "$RADIO" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate"
+						wifi_update "$SECTION" "$RADIO" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 						NEEDCOMMIT=1
 						FOUND=1
 					fi
 				fi
 			done
-			if [ $FOUND -eq 0 ]; then
-				wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate"
+
+			if [ "$FOUND" -eq 0 ]; then
+				wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 				NEEDCOMMIT=1
 			fi
 		done
@@ -142,13 +207,13 @@ while json_is_a $IDX object; do
 	json_select ..
 done
 
-if [ $NEEDCOMMIT -eq 1 ]; then
+if [ "$NEEDCOMMIT" -eq 1 ]; then
 	uci commit wireless
 	wifi reload
 fi
 
-rm "$FILE"
-[ -e /tmp/apcontroller.user ] && rm /tmp/apcontroller.user
-[ -e /tmp/apcontroller-agent-as ] && rm /tmp/apcontroller-agent-as
+rm -f "$FILE"
+[ -e /tmp/apcontroller.user ] && rm -f /tmp/apcontroller.user
+[ -e /tmp/apcontroller-agent-as ] && rm -f /tmp/apcontroller-agent-as
 
 exit 0

--- a/apcontroller/files/usr/share/apcontroller/apcontroller-agent-setconfig
+++ b/apcontroller/files/usr/share/apcontroller/apcontroller-agent-setconfig
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-FILE="$1"
-
+FILE=$1
 [ -s "$FILE" ] || exit 1
+
 [ -e /etc/config/wireless ] || exit 1
 
-wifi_set_macfilter() {
+function wifi_set_macfilter() {
 	local SEC="$1"
 	local MACFILTER="$2"
 	local MACLIST="$3"
@@ -27,73 +27,64 @@ wifi_set_macfilter() {
 	esac
 }
 
-wifi_add() {
-	local RADIO="$1"
-	local NETWORK="$2"
-	local ENABLED="$3"
-	local SSID="$4"
-	local ENCRYPTION="$5"
-	local KEY="$6"
-	local HIDDEN="$7"
-	local ISOLATE="$8"
-	local MACFILTER="$9"
+function wifi_add() {
+	local RADIO=$1
+	local NETWORK=$2
+	local ENABLED=$3
+	local SSID=$4
+	local ENCRYPTION=$5
+	local KEY=$6
+	local HIDDEN=$7
+	local ISOLATE=$8
+	local MACFILTER=$9
 	local MACLIST="${10}"
 
-	CNT="$(uci show wireless | awk '/\.device=/ {count++} END {print count + 1}')"
-
+	CNT=$(uci show wireless | awk '/\.device=/ {count++} END {print count + 1}')
 	while [ -n "$(uci -q get wireless.wifinet"$CNT")" ]; do
 		CNT=$((CNT + 1))
 	done
-
 	SEC="wifinet${CNT}"
 
 	uci set wireless."$SEC"=wifi-iface
-	uci set wireless."$SEC".device="$RADIO"
+	uci set wireless."$SEC".device=$RADIO
 	uci set wireless."$SEC".mode=ap
 	uci set wireless."$SEC".network="$NETWORK"
-
 	if [ "$ENABLED" -eq 0 ]; then
 		uci set wireless."$SEC".disabled=1
 	else
 		uci -q del wireless."$RADIO".disabled
 	fi
-
 	uci set wireless."$SEC".ssid="$SSID"
 	uci set wireless."$SEC".encryption="$ENCRYPTION"
 	uci set wireless."$SEC".key="$KEY"
 	uci set wireless."$SEC".hidden="${HIDDEN:-0}"
 	uci set wireless."$SEC".isolate="${ISOLATE:-0}"
-
 	wifi_set_macfilter "$SEC" "$MACFILTER" "$MACLIST"
 }
 
-wifi_update() {
-	local SEC="$1"
-	local RADIO="$2"
-	local ENABLED="$3"
-	local SSID="$4"
-	local ENCRYPTION="$5"
-	local KEY="$6"
-	local HIDDEN="$7"
-	local ISOLATE="$8"
-	local MACFILTER="$9"
+function wifi_update() {
+	local SEC=$1
+	local RADIO=$2
+	local ENABLED=$3
+	local SSID=$4
+	local ENCRYPTION=$5
+	local KEY=$6
+	local HIDDEN=$7
+	local ISOLATE=$8
 	local MACLIST="${10}"
 
 	uci -q del wireless."$RADIO".disabled
-
 	if [ "$ENABLED" -eq 0 ]; then
 		uci set wireless."$SEC".disabled=1
 	else
 		uci -q del wireless."$RADIO".disabled
 		uci -q del wireless."$SEC".disabled
 	fi
-
 	uci set wireless."$SEC".ssid="$SSID"
 	uci set wireless."$SEC".encryption="$ENCRYPTION"
 	uci set wireless."$SEC".key="$KEY"
 	uci set wireless."$SEC".hidden="${HIDDEN:-0}"
 	uci set wireless."$SEC".isolate="${ISOLATE:-0}"
-
 	wifi_set_macfilter "$SEC" "$MACFILTER" "$MACLIST"
 }
 
@@ -102,27 +93,22 @@ wifi_update() {
 NEEDCOMMIT=0
 
 json_load_file "$FILE"
+
 json_is_a wifis array || exit 2
 
 json_get_var delete delete
-
 if [ "x$delete" = "x1" ]; then
-	EXISTING="$(uci show wireless | awk -F[.=] '/=wifi-iface$/{print $2}')"
-
+	EXISTING=$(uci show wireless | awk -F[.=] '/=wifi-iface$/{print $2}')
 	for SECTION in $EXISTING; do
 		uci -q del wireless."$SECTION"
 	done
-
 	NEEDCOMMIT=1
 fi
 
 json_select "wifis"
-
 IDX=1
-
-while json_is_a "$IDX" object; do
-	json_select "$IDX"
-
+while json_is_a $IDX object; do
+	json_select $IDX
 	json_get_vars enabled band network ssid encryption key hidden isolate macfilter
 
 	[ -z "$macfilter" ] && macfilter="disable"
@@ -143,7 +129,7 @@ while json_is_a "$IDX" object; do
 
 	[ -e /tmp/apcontroller.user ] && sh /tmp/apcontroller-agent-as "$enabled" "$ssid" "$band" "$network"
 
-	T="$(uci -q get network."$network")"
+	T=$(uci -q get network."$network")
 	if [ -z "$T" ]; then
 		IDX=$((IDX + 1))
 		json_select ..
@@ -151,43 +137,36 @@ while json_is_a "$IDX" object; do
 	fi
 
 	RADIOS=""
-
 	case "$band" in
 		"2g")
-			RADIOS="$(uci show wireless | awk -F. '/\.hwmode='\''11g'\''$|\.band='\''2g'\''/{print $2}')"
+			RADIOS=$(uci show wireless | awk -F. '/\.hwmode='\''11g'\''$|\.band='\''2g'\''/{print $2}')
 		;;
 		"5g")
-			RADIOS="$(uci show wireless | awk -F. '/\.hwmode='\''11a'\''$|\.band='\''5g'\''/{print $2}')"
+			RADIOS=$(uci show wireless | awk -F. '/\.hwmode='\''11a'\''$|\.band='\''5g'\''/{print $2}')
 		;;
 		"6g")
-			RADIOS="$(uci show wireless | awk -F. '/\.band='\''6g'\''/{print $2}')"
+			RADIOS=$(uci show wireless | awk -F. '/\.band='\''6g'\''/{print $2}')
 		;;
 	esac
-
 	if [ -z "$RADIOS" ]; then
 		IDX=$((IDX + 1))
 		json_select ..
 		continue
 	fi
 
-	SECTIONS="$(uci -q show wireless | awk -F. '/\.ssid='\'''"$ssid"''\''$/{print $2}')"
-
+	SECTIONS=$(uci -q show wireless | awk -F. '/\.ssid='\'''"$ssid"''\''$/{print $2}')
 	if [ -z "$SECTIONS" ]; then
 		for RADIO in $RADIOS; do
 			wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 		done
-
 		NEEDCOMMIT=1
 	else
 		for RADIO in $RADIOS; do
 			FOUND=0
-
 			for SECTION in $SECTIONS; do
-				T1="$(uci get wireless."$SECTION".device)"
-
+				T1=$(uci get wireless."$SECTION".device)
 				if [ "$T1" = "$RADIO" ]; then
-					T2="$(uci get wireless."$SECTION".network)"
-
+					T2=$(uci get wireless."$SECTION".network)
 					if [ "$T2" = "$network" ]; then
 						wifi_update "$SECTION" "$RADIO" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 						NEEDCOMMIT=1
@@ -195,8 +174,7 @@ while json_is_a "$IDX" object; do
 					fi
 				fi
 			done
-
-			if [ "$FOUND" -eq 0 ]; then
+			if [ $FOUND -eq 0 ]; then
 				wifi_add "$RADIO" "$network" "$enabled" "$ssid" "$encryption" "$key" "$hidden" "$isolate" "$macfilter" "$MACLIST"
 				NEEDCOMMIT=1
 			fi
@@ -207,13 +185,13 @@ while json_is_a "$IDX" object; do
 	json_select ..
 done
 
-if [ "$NEEDCOMMIT" -eq 1 ]; then
+if [ $NEEDCOMMIT -eq 1 ]; then
 	uci commit wireless
 	wifi reload
 fi
 
-rm -f "$FILE"
-[ -e /tmp/apcontroller.user ] && rm -f /tmp/apcontroller.user
-[ -e /tmp/apcontroller-agent-as ] && rm -f /tmp/apcontroller-agent-as
+rm "$FILE"
+[ -e /tmp/apcontroller.user ] && rm /tmp/apcontroller.user
+[ -e /tmp/apcontroller-agent-as ] && rm /tmp/apcontroller-agent-as
 
 exit 0

--- a/luci-app-apcontroller/htdocs/luci-static/resources/view/apcontroller/apcontroller.js
+++ b/luci-app-apcontroller/htdocs/luci-static/resources/view/apcontroller/apcontroller.js
@@ -1056,6 +1056,20 @@ return view.extend({
 		};
 		o.default = 'lan';
 
+		o = s.taboption('wifi', form.ListValue, 'macfilter', _('MAC Address Filter'));
+                o.modalonly = true;
+                o.rmempty = false;
+                o.default = 'disable';
+                o.value('disable', _('Disabled'));
+                o.value('allow', _('Allow listed only'));
+                o.value('deny', _('Deny listed'));
+        
+                o = s.taboption('wifi', form.DynamicList, 'maclist', _('MAC Address List'));
+                o.modalonly = true;
+                o.rmempty = true;
+                o.datatype = 'macaddr';
+                o.depends('macfilter', 'allow');
+                o.depends('macfilter', 'deny');
 
 		// AP Group tab
 		s = m.section(form.GridSection, 'group', _('AP Group'));


### PR DESCRIPTION
## Summary

This PR adds MAC address filter support to WiFi profiles managed by apcontroller.

The new profile options are:

- `macfilter`
  - `disable`
  - `allow`
  - `deny`
- `maclist`
  - list of MAC addresses

The options are exposed in the LuCI WiFi profile form and transferred to managed APs via the existing config deployment mechanism.

## Behavior

For each managed WiFi interface, the agent now sets:

```uci
option macfilter 'allow|deny'
list maclist 'AA:BB:CC:DD:EE:FF'